### PR TITLE
Add UI playground documentation and demo page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,34 @@
-# React + TypeScript + Vite
+# Fandom UI Sandbox
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+A Vite + React + Tailwind playground for experimenting with UI ideas before they ship. The repository is intentionally lightweight so teammates can explore patterns, iterate on tokens, and share snippets quickly.
 
-Currently, two official plugins are available:
+## Getting started
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+1. **Install dependencies**
+   ```bash
+   npm install
+   ```
+2. **Start the dev server**
+   ```bash
+   npm run dev
+   ```
+   The app opens to the playground so you can tinker with example components right away.
 
-## Expanding the ESLint configuration
+For the best experience use the active LTS version of Node.js (v18+) and enable your editor's ESLint + TypeScript integrations.
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+## Available scripts
 
-```js
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
+| Command | Description |
+| --- | --- |
+| `npm run dev` | Runs Vite's development server with hot module reloading. |
+| `npm run build` | Type-checks the project and outputs a production build to `dist/`. |
+| `npm run lint` | Lints all source files using the shared ESLint configuration. |
+| `npm run preview` | Serves the production build locally for smoke testing. |
 
-      // Remove tseslint.configs.recommended and replace with this
-      ...tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      ...tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      ...tseslint.configs.stylisticTypeChecked,
+## Playground overview
 
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
+- The primary sandbox lives in [`src/pages/Playground.tsx`](src/pages/Playground.tsx).
+- It renders a grid of buttons, cards, and typography samples styled with Tailwind utility classes.
+- Update this page as you experiment with new design tokens, interaction states, or documentation snippets.
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
-
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
+Use the navigation in the header to jump between the overview hero and the playground. When you are ready to promote a component into the product, lift the relevant patterns into the feature's module.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,27 +1,84 @@
+import { useState } from 'react'
+
 import { Button } from './components/Button'
+import { Playground } from './pages/Playground'
+
+const tabs = [
+  { id: 'playground', label: 'Playground' },
+  { id: 'overview', label: 'Overview' },
+] as const
+
+type TabId = (typeof tabs)[number]['id']
 
 function App() {
+  const [activeTab, setActiveTab] = useState<TabId>('playground')
+
+  const baseTabClasses =
+    'rounded-full px-4 py-2 text-sm font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2'
+  const activeTabClasses = 'bg-emerald-500 text-emerald-950 shadow shadow-emerald-500/40 focus-visible:outline-emerald-300'
+  const inactiveTabClasses = 'text-slate-300 hover:text-white focus-visible:outline-emerald-500'
+
   return (
-    <div className="flex min-h-screen items-center justify-center bg-slate-950 px-6 py-16 text-slate-100">
-      <main className="max-w-2xl space-y-8 text-center">
-        <span className="inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-4 py-1 text-sm font-medium text-emerald-300 ring-1 ring-inset ring-emerald-500/30">
-          <span className="h-2 w-2 rounded-full bg-emerald-400" aria-hidden />
-          Tailwind CSS Ready
-        </span>
-        <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
-          Ship polished interfaces at warp speed
-        </h1>
-        <p className="text-lg text-slate-300">
-          Tailwind CSS is wired up and ready to go. Start building by composing
-          utility classes directly in your components, and customize the design
-          system in <code className="font-mono text-emerald-300">tailwind.config.js</code> as you grow.
-        </p>
-        <div className="flex flex-wrap items-center justify-center gap-4">
-          <Button>Get Started</Button>
-          <Button variant="secondary">View Docs</Button>
+    <div className="flex min-h-screen flex-col bg-slate-950 text-slate-100">
+      <header className="border-b border-white/10 bg-slate-950/80 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-6 py-4">
+          <div className="space-y-1">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300">Fandom</p>
+            <p className="text-lg font-semibold tracking-tight text-white">UI Sandbox</p>
+            <p className="text-sm text-slate-400">Prototype components before promoting them to features.</p>
+          </div>
+          <nav aria-label="Primary navigation" className="flex items-center gap-2">
+            {tabs.map((tab) => {
+              const isActive = tab.id === activeTab
+              return (
+                <button
+                  key={tab.id}
+                  type="button"
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`${baseTabClasses} ${isActive ? activeTabClasses : inactiveTabClasses}`}
+                >
+                  {tab.label}
+                </button>
+              )
+            })}
+          </nav>
         </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-6xl flex-1 px-6 py-12">
+        {activeTab === 'playground' ? <Playground /> : <Overview />}
       </main>
+
+      <footer className="border-t border-white/10 bg-slate-950/80">
+        <div className="mx-auto max-w-6xl px-6 py-4 text-sm text-slate-500">
+          Keep iterating on{' '}
+          <code className="rounded bg-slate-900/70 px-1.5 py-0.5 text-xs text-slate-300">src/pages/Playground.tsx</code>{' '}
+          to share new experiments with the team.
+        </div>
+      </footer>
     </div>
+  )
+}
+
+function Overview() {
+  return (
+    <section className="space-y-8 rounded-3xl bg-slate-900/60 p-10 text-center shadow-xl shadow-black/20 ring-1 ring-white/10">
+      <span className="inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-4 py-1 text-sm font-medium text-emerald-300 ring-1 ring-inset ring-emerald-500/30">
+        <span className="h-2 w-2 rounded-full bg-emerald-400" aria-hidden />
+        Tailwind CSS Ready
+      </span>
+      <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
+        Ship polished interfaces at warp speed
+      </h1>
+      <p className="text-lg text-slate-300">
+        Tailwind CSS is wired up and ready to go. Start building by composing utility classes directly in your components, and
+        customize the design system in <code className="font-mono text-emerald-300">tailwind.config.js</code> as you grow.
+      </p>
+      <div className="flex flex-wrap items-center justify-center gap-4">
+        <Button>Get Started</Button>
+        <Button variant="secondary">View Docs</Button>
+      </div>
+    </section>
   )
 }
 

--- a/src/pages/Playground.tsx
+++ b/src/pages/Playground.tsx
@@ -1,0 +1,194 @@
+import { Button } from '../components/Button'
+
+const cards = [
+  {
+    title: 'Creator Spotlight',
+    description:
+      'Celebrate top community contributors with curated highlights, playlists, and stats that update in real time.',
+    badge: 'Community',
+    cta: 'Open report',
+    meta: 'Updated 2 days ago',
+    support: '12 creators featured',
+    variant: 'primary' as const,
+  },
+  {
+    title: 'Episode Tracker',
+    description:
+      'Provide release schedules, reminders, and progress tracking for shows your fandom follows closely.',
+    badge: 'Product',
+    cta: 'View tracker',
+    meta: 'Syncs nightly',
+    support: 'Calendar connected',
+    variant: 'secondary' as const,
+  },
+  {
+    title: 'Event Promo',
+    description:
+      'Pair key art with layered copy and CTAs to promote upcoming panels, meetups, or limited-time drops.',
+    badge: 'Marketing',
+    cta: 'Preview banner',
+    meta: 'Campaign live',
+    support: 'Ends July 28',
+    variant: 'primary' as const,
+  },
+] satisfies Array<{
+  title: string
+  description: string
+  badge: string
+  cta: string
+  meta: string
+  support: string
+  variant: 'primary' | 'secondary'
+}>
+
+const typeSamples = [
+  {
+    label: 'Display / XL',
+    example: 'Legends begin with a single spark.',
+    className: 'text-4xl font-semibold tracking-tight text-slate-50 sm:text-5xl',
+    description: 'Use for hero headlines and high-impact storytelling moments.',
+  },
+  {
+    label: 'Heading / L',
+    example: 'Crew updates',
+    className: 'text-2xl font-semibold text-slate-100',
+    description: 'Ideal for section headers and card titles that need hierarchy.',
+  },
+  {
+    label: 'Body / Base',
+    example: 'Collaborate in real time with shared editing, presence, and review workflows.',
+    className: 'text-base text-slate-300',
+    description: 'Default body copy for articles, product descriptions, and feature callouts.',
+  },
+  {
+    label: 'Caption / XS',
+    example: 'Updated moments ago',
+    className: 'text-xs uppercase tracking-[0.25em] text-slate-400',
+    description: 'Use for metadata, table headers, tooltips, or supporting labels.',
+  },
+] satisfies Array<{
+  label: string
+  example: string
+  className: string
+  description: string
+}>
+
+export function Playground() {
+  const panelClasses =
+    'rounded-2xl bg-slate-900/60 p-6 shadow-lg shadow-black/10 ring-1 ring-white/10 transition hover:ring-emerald-400/30'
+
+  return (
+    <div className="space-y-12">
+      <header className="space-y-3 text-center md:text-left">
+        <span className="inline-flex items-center gap-2 self-center rounded-full bg-emerald-500/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-emerald-300 ring-1 ring-inset ring-emerald-500/30 md:self-start">
+          Playground
+        </span>
+        <h1 className="text-4xl font-bold tracking-tight text-white sm:text-5xl">Component playground</h1>
+        <p className="mx-auto max-w-3xl text-base text-slate-300 md:mx-0 md:text-lg">
+          Mix and match Tailwind utility classes, swap tokens, and experiment with component compositions. Use these samples as
+          starting points when pairing with designers or documenting patterns for the team.
+        </p>
+      </header>
+
+      <section className="space-y-4" aria-labelledby="button-showcase">
+        <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+          <div className="space-y-1">
+            <h2 id="button-showcase" className="text-2xl font-semibold text-white">
+              Buttons
+            </h2>
+            <p className="text-sm text-slate-400 md:text-base">
+              Action styles inherit from <code className="font-mono text-emerald-300">Button.tsx</code>. Adjust utility classes to
+              explore new emphasis levels.
+            </p>
+          </div>
+          <code className="inline-flex items-center gap-2 self-start rounded-full bg-slate-900/80 px-3 py-1 text-xs font-medium text-slate-400 ring-1 ring-white/10">
+            src/components/Button.tsx
+          </code>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <article className={`${panelClasses} space-y-4`}>
+            <div className="space-y-1">
+              <p className="text-sm font-semibold text-emerald-300">Primary</p>
+              <p className="text-sm text-slate-400">
+                High-emphasis action for hero flows and key conversions.
+              </p>
+            </div>
+            <Button>
+              Launch mission
+              <span aria-hidden className="text-lg leading-none">→</span>
+            </Button>
+          </article>
+          <article className={`${panelClasses} space-y-4`}>
+            <div className="space-y-1">
+              <p className="text-sm font-semibold text-emerald-300">Secondary</p>
+              <p className="text-sm text-slate-400">
+                Low-emphasis option with a subtle border and hover state.
+              </p>
+            </div>
+            <Button variant="secondary">View changelog</Button>
+          </article>
+          <article className={`${panelClasses} space-y-4`}>
+            <div className="space-y-1">
+              <p className="text-sm font-semibold text-emerald-300">Disabled</p>
+              <p className="text-sm text-slate-400">
+                Use for pending states or actions gated by permissions.
+              </p>
+            </div>
+            <Button disabled>Processing…</Button>
+          </article>
+        </div>
+      </section>
+
+      <section className="space-y-4" aria-labelledby="card-gallery">
+        <div className="space-y-1">
+          <h2 id="card-gallery" className="text-2xl font-semibold text-white">
+            Cards
+          </h2>
+          <p className="text-sm text-slate-400 md:text-base">
+            Present feature concepts with badges, copy, and clear calls to action. Duplicate these tiles to sketch new modules.
+          </p>
+        </div>
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {cards.map((card) => (
+            <article key={card.title} className={`${panelClasses} flex flex-col gap-4`}>
+              <div className="space-y-2">
+                <span className="inline-flex w-fit items-center gap-2 rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-emerald-300">
+                  {card.badge}
+                </span>
+                <h3 className="text-xl font-semibold text-white">{card.title}</h3>
+                <p className="text-sm text-slate-300">{card.description}</p>
+              </div>
+              <div className="flex items-center justify-between text-xs text-slate-500">
+                <span>{card.meta}</span>
+                <span>{card.support}</span>
+              </div>
+              <Button variant={card.variant} className="w-full justify-center">
+                {card.cta}
+              </Button>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-4" aria-labelledby="type-scale">
+        <div className="space-y-1">
+          <h2 id="type-scale" className="text-2xl font-semibold text-white">
+            Typography
+          </h2>
+          <p className="text-sm text-slate-400 md:text-base">
+            Apply the scale below to keep rhythm across marketing surfaces, dashboards, and in-product education moments.
+          </p>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          {typeSamples.map((sample) => (
+            <article key={sample.label} className={`${panelClasses} space-y-2`}>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-emerald-300">{sample.label}</p>
+              <p className={sample.className}>{sample.example}</p>
+              <p className="text-sm text-slate-400">{sample.description}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- replace the README with sandbox setup steps, script references, and a quick tour of the playground
- update the app shell to surface the playground on load and provide navigation between the sandbox and overview hero
- build a dedicated playground page that showcases button, card, and typography patterns styled with Tailwind

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9a50460548320bba7d14ccd6df882